### PR TITLE
fix: standardize on using config cascade instead of flat settings

### DIFF
--- a/examples/client/config.ts
+++ b/examples/client/config.ts
@@ -7,6 +7,6 @@ export default require('./package.json').cxp as {
     documentSelector: DocumentSelector
     initializationOptions: {
         mode: string
-        settings: { merged: any }
+        configurationCascade: { merged: any }
     }
 }

--- a/examples/client/package.json
+++ b/examples/client/package.json
@@ -21,7 +21,7 @@
     ],
     "initializationOptions": {
       "mode": "sample/line-colors",
-      "settings": {
+      "configurationCascade": {
         "merged": {
           "colors": [
             "red"

--- a/src/client/features/configuration.test.ts
+++ b/src/client/features/configuration.test.ts
@@ -1,18 +1,18 @@
 import * as assert from 'assert'
 import { Subject } from 'rxjs'
-import { ClientCapabilities } from '../../protocol'
+import { ClientCapabilities, ConfigurationCascade } from '../../protocol'
 import { Client } from '../client'
 import { ConfigurationChangeNotificationFeature } from './configuration'
 
 const create = (): {
     client: Client
-    settings: Subject<any>
-    feature: ConfigurationChangeNotificationFeature<any>
+    configurationCascade: Subject<ConfigurationCascade>
+    feature: ConfigurationChangeNotificationFeature<ConfigurationCascade>
 } => {
     const client = { options: { middleware: {} } } as Client
-    const settings = new Subject<any>()
-    const feature = new ConfigurationChangeNotificationFeature(client, settings)
-    return { client, settings, feature }
+    const configurationCascade = new Subject<ConfigurationCascade>()
+    const feature = new ConfigurationChangeNotificationFeature(client, configurationCascade)
+    return { client, configurationCascade, feature }
 }
 
 describe('ConfigurationChangeNotificationFeature', () => {

--- a/src/environment/controller.ts
+++ b/src/environment/controller.ts
@@ -20,6 +20,7 @@ import { WindowShowMessageFeature } from '../client/features/message'
 import { TextDocumentDidCloseFeature, TextDocumentDidOpenFeature } from '../client/features/textDocument'
 import { Trace } from '../jsonrpc2/trace'
 import {
+    ConfigurationCascade,
     ConfigurationUpdateParams,
     InitializeParams,
     LogMessageParams,
@@ -64,9 +65,9 @@ type ConfigurationUpdate = ConfigurationUpdateParams & MessageSource & PromiseCa
  * Options for creating the controller.
  *
  * @template X extension type
- * @template C settings type
+ * @template C configuration cascade type
  */
-export interface ControllerOptions<X extends Extension, C extends object> {
+export interface ControllerOptions<X extends Extension, C extends ConfigurationCascade> {
     /** Returns additional options to use when creating a client. */
     clientOptions: (
         key: ClientKey,
@@ -87,9 +88,9 @@ export interface ControllerOptions<X extends Extension, C extends object> {
  * The controller for the environment.
  *
  * @template X extension type
- * @template C settings type
+ * @template C configuration cascade type
  */
-export class Controller<X extends Extension, C extends object> implements Unsubscribable {
+export class Controller<X extends Extension, C extends ConfigurationCascade> implements Unsubscribable {
     private _environment = new BehaviorSubject<Environment<X, C>>(EMPTY_ENVIRONMENT)
 
     private _clientEntries = new BehaviorSubject<ClientEntry[]>([])
@@ -160,7 +161,7 @@ export class Controller<X extends Extension, C extends object> implements Unsubs
                 unusedClients.push(oldClient)
             } else {
                 // Client already exists. Settings may have changed, but ConfigurationFeature is responsible for
-                // notifying the server of settings changes.
+                // notifying the server of configuration changes.
                 newClients.splice(newIndex, 1)
                 nextClients.push(oldClient)
             }

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,6 +1,7 @@
 import { Observable, of } from 'rxjs'
 import { distinctUntilChanged, map } from 'rxjs/operators'
 import { Range, TextDocument, TextDocumentItem } from 'vscode-languageserver-types'
+import { ConfigurationCascade } from '../protocol'
 import { Selection, URI } from '../types/textDocument'
 import { isEqual } from '../util'
 import { Extension } from './extension'
@@ -12,9 +13,9 @@ import { Extension } from './extension'
  * and support extension configuration.
  *
  * @template X extension type, to support storing additional properties on extensions
- * @template C settings type
+ * @template C configuration cascade type
  */
-export interface Environment<X extends Extension = Extension, C extends object = { [key: string]: any }> {
+export interface Environment<X extends Extension = Extension, C extends ConfigurationCascade = ConfigurationCascade> {
     /**
      * The root URI of the environment, or null if there is none (which means the extension is unable to access any
      * documents in the environment).
@@ -31,7 +32,7 @@ export interface Environment<X extends Extension = Extension, C extends object =
     /** The active extensions, or null if there are none. */
     readonly extensions: X[] | null
 
-    /** The configuration settings. */
+    /** The configuration cascade. */
     readonly configuration: C
 }
 
@@ -40,7 +41,7 @@ export const EMPTY_ENVIRONMENT: Environment<any, any> = {
     root: null,
     component: null,
     extensions: null,
-    configuration: {},
+    configuration: { merged: {} },
 }
 
 /** An application component that displays a [TextDocument](#TextDocument). */
@@ -64,9 +65,9 @@ export interface Component {
  * Includes derived observables for convenience.
  *
  * @template X extension type, to support storing additional properties on extensions
- * @template C settings type
+ * @template C configuration cascade type
  */
-export interface ObservableEnvironment<X extends Extension, C extends object> {
+export interface ObservableEnvironment<X extends Extension, C extends ConfigurationCascade> {
     /** The environment (and changes to it). */
     readonly environment: Observable<Environment<X, C>> & { readonly value: Environment<X, C> }
 
@@ -79,7 +80,7 @@ export interface ObservableEnvironment<X extends Extension, C extends object> {
     /** The active component's text document (and changes to it). */
     readonly textDocument: Observable<Pick<TextDocument, 'uri' | 'languageId'> | null>
 
-    /** The environment's configuration (and changes to it). */
+    /** The environment's configuration cascade (and changes to it). */
     readonly configuration: Observable<C>
 }
 
@@ -99,9 +100,9 @@ export const EMPTY_OBSERVABLE_ENVIRONMENT: ObservableEnvironment<any, any> = {
  * Helper function for creating an ObservableEnvironment from the raw environment Observable.
  *
  * @template X extension type
- * @template C settings type
+ * @template C configuration cascade type
  */
-export function createObservableEnvironment<X extends Extension, C extends object>(
+export function createObservableEnvironment<X extends Extension, C extends ConfigurationCascade>(
     environment: Observable<Environment<X, C>> & { readonly value: Environment<X, C> }
 ): ObservableEnvironment<X, C> {
     const component = environment.pipe(

--- a/src/environment/extension.ts
+++ b/src/environment/extension.ts
@@ -1,4 +1,4 @@
-/** An extension's identifier and settings. */
+/** An extension's identifier. */
 export interface Extension {
     /** The extension ID. */
     readonly id: string

--- a/src/protocol/configuration.ts
+++ b/src/protocol/configuration.ts
@@ -11,7 +11,9 @@ export interface ConfigurationUpdateParams {
     value: any
 }
 
-/** The configuration/update request, which the server sends to the client to update the client's settings. */
+/**
+ * The configuration/update request, which the server sends to the client to update the client's configuration.
+ */
 export namespace ConfigurationUpdateRequest {
     export const type = new RequestType<ConfigurationUpdateParams, void, void, void>('configuration/update')
 }
@@ -79,7 +81,15 @@ export interface DidChangeConfigurationRegistrationOptions {
  */
 export interface DidChangeConfigurationParams {
     /**
-     * The actual changed settings
+     * The new configuration cascade, after the change was applied.
      */
-    settings: any
+    configurationCascade: ConfigurationCascade
+}
+
+/**
+ * The merged configuration from a configuration cascade.
+ */
+export interface ConfigurationCascade {
+    /** The final settings, merged from all levels in the cascade. */
+    merged: any
 }


### PR DESCRIPTION
Consumers of this library could choose whether to make the `C` generic type parameter a `{merged: Settings}` type or just a `Settings` type. This was confusing. Now it is enforced to be the former.

BREAKING CHANGE: The environment configuration must be a configuration cascade, not just the merged settings.