### PR TITLE
feat(context): add context exprs for contribution enablement

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -27,3 +27,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -------------------------------------------------------------------------------
+
+# https://github.com/ariya/tapdigit
+
+Copyright (c) 2018, Ariya Hidayat. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/client/features/contribution.test.ts
+++ b/src/client/features/contribution.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+import { EMPTY_OBSERVABLE_ENVIRONMENT } from '../../environment/environment'
 import { ContributionRegistry, ContributionsEntry } from '../../environment/providers/contribution'
 import { ClientCapabilities } from '../../protocol'
 import { Client } from '../client'
@@ -10,7 +11,7 @@ const create = (): {
     feature: ContributionFeature
 } => {
     const client = {} as Client
-    const registry = new ContributionRegistry()
+    const registry = new ContributionRegistry(EMPTY_OBSERVABLE_ENVIRONMENT.context)
     const feature = new ContributionFeature(registry)
     return { client, registry, feature }
 }

--- a/src/environment/context/context.test.ts
+++ b/src/environment/context/context.test.ts
@@ -1,0 +1,117 @@
+import assert from 'assert'
+import { EMPTY_ENVIRONMENT } from '../environment'
+import { Context, contextFilter, createChildContext, environmentContext } from './context'
+
+const throwContext: Context = {
+    get(): any {
+        throw new Error('no next context')
+    },
+}
+
+describe('createChildContext', () => {
+    it('creates a child context', () => {
+        const parent: Context = new Map([['a', 1]])
+        const child = createChildContext(parent)
+        assert.strictEqual(child.get('a'), 1)
+        assert.strictEqual(child.get('b'), undefined)
+        child.set('b', 2)
+        assert.strictEqual(child.get('b'), 2)
+        child.set('a', 3)
+        assert.strictEqual(child.get('a'), 3)
+        assert.strictEqual(parent.get('a'), 1)
+        child.set('a', undefined)
+        assert.strictEqual(child.get('a'), 1)
+        assert.strictEqual(parent.get('a'), 1)
+    })
+})
+
+describe('environmentContext', () => {
+    it('provides config', () => {
+        const context = environmentContext(
+            {
+                ...EMPTY_ENVIRONMENT,
+                configuration: {
+                    merged: {
+                        a: 1,
+                        'a.b': 2,
+                        'c.d': 3,
+                    },
+                },
+            },
+            throwContext
+        )
+        assert.strictEqual(context.get('config.a'), 1)
+        assert.strictEqual(context.get('config.a.b'), 2)
+        assert.strictEqual(context.get('config.c.d'), 3)
+        assert.strictEqual(context.get('config.x'), null)
+    })
+
+    describe('environment with component', () => {
+        const context = environmentContext(
+            {
+                ...EMPTY_ENVIRONMENT,
+                component: {
+                    document: {
+                        uri: 'file:///a/b.c',
+                        languageId: 'l',
+                        version: 0,
+                        text: 't',
+                    },
+                    selections: [],
+                    visibleRanges: [],
+                },
+            },
+            throwContext
+        )
+
+        describe('resource', () => {
+            it('provides resource.uri', () => assert.strictEqual(context.get('resource.uri'), 'file:///a/b.c'))
+            it('provides resource.basename', () => assert.strictEqual(context.get('resource.basename'), 'b.c'))
+            it('provides resource.dirname', () => assert.strictEqual(context.get('resource.dirname'), 'file:///a'))
+            it('provides resource.extname', () => assert.strictEqual(context.get('resource.extname'), '.c'))
+            it('provides resource.language', () => assert.strictEqual(context.get('resource.language'), 'l'))
+            it('provides resource.textContent', () => assert.strictEqual(context.get('resource.textContent'), 't'))
+            it('provides resource.type', () => assert.strictEqual(context.get('resource.type'), 'textDocument'))
+
+            it('returns undefined when the environment has no component', () =>
+                assert.strictEqual(environmentContext(EMPTY_ENVIRONMENT, throwContext).get('resource.uri'), undefined))
+        })
+
+        describe('component', () => {
+            it('provides component.type', () => assert.strictEqual(context.get('component.type'), 'textEditor'))
+
+            it('returns undefined when the environment has no component', () =>
+                assert.strictEqual(
+                    environmentContext(EMPTY_ENVIRONMENT, throwContext).get('component.type'),
+                    undefined
+                ))
+        })
+    })
+
+    it('falls back to the next context', () => {
+        assert.strictEqual(environmentContext(EMPTY_ENVIRONMENT, { get: () => 1 }).get('x'), 1)
+        assert.throws(() => environmentContext(EMPTY_ENVIRONMENT, throwContext).get('x'))
+    })
+})
+
+describe('contextFilter', () => {
+    const FIXTURE_CONTEXT = new Map<string, any>(
+        Object.entries({
+            a: 1,
+            b: 1,
+            c: 2,
+            x: 'y',
+        })
+    )
+
+    it('filters', () =>
+        assert.deepStrictEqual(
+            contextFilter(FIXTURE_CONTEXT, [
+                { x: 1 },
+                { x: 2, when: 'a' },
+                { x: 3, when: 'a == b' },
+                { x: 4, when: 'a == c' },
+            ]),
+            [{ x: 1 }, { x: 2, when: 'a' }, { x: 3, when: 'a == b' }]
+        ))
+})

--- a/src/environment/context/context.ts
+++ b/src/environment/context/context.ts
@@ -1,0 +1,124 @@
+import { basename, dirname, extname } from 'path'
+import { ConfigurationCascade } from '../../protocol'
+import { Environment } from '../environment'
+import { Extension } from '../extension'
+import { evaluate } from './expr/evaluator'
+
+/**
+ * Context is an arbitrary, immutable set of key-value pairs.
+ */
+export interface Context {
+    get(key: string): any
+}
+
+/**
+ * A mutable context is a Context whose values can be set.
+ */
+export interface MutableContext extends Context {
+    set(name: string, value: any): void
+}
+
+/**
+ * Creates a new child context. All of the parent's values are available in the child context. Any values set on
+ * the child context shadow parent context values. Setting the child context's values never modifies the parent
+ * context (even if the parent is a MutableContext itself).
+ */
+export function createChildContext(parent: Context): MutableContext {
+    const values = new Map<string, any>()
+    return {
+        get: (key: string): any => {
+            const value = values.get(key)
+            if (value !== undefined) {
+                return value
+            }
+            return parent.get(key)
+        },
+        set: (name: string, value: any): void => {
+            values.set(name, value)
+        },
+    }
+}
+
+/** A Context that is empty (and returns undefined for every key). */
+export const EMPTY_CONTEXT: Context = {
+    get(): any {
+        return undefined
+    },
+}
+
+/**
+ * Wraps the environment's context, providing some context properties by deriving them from the
+ * environment.
+ *
+ * @template X extension type
+ * @template C configuration cascade type
+ * @param next the context to use when the key doesn't refer to a property derived from the
+ * environment
+ */
+export function environmentContext<X extends Extension, C extends ConfigurationCascade>(
+    environment: Environment<X, C>,
+    next: Context
+): Context {
+    return {
+        get(key: string): any {
+            if (key.startsWith('config.')) {
+                const prop = key.slice('config.'.length)
+                const value = environment.configuration.merged[prop]
+                // Map undefined to null because an undefined value is treated as "does not exist in
+                // context" and an error is thrown, which is undesirable for config values (for
+                // which a falsey null default is useful).
+                return value === undefined ? null : value
+            }
+            if (key === 'resource' || key === 'component') {
+                return !!environment.component
+            }
+            if (key.startsWith('resource.')) {
+                if (!environment.component) {
+                    return undefined
+                }
+                const prop = key.slice('resource.'.length)
+                switch (prop) {
+                    case 'uri':
+                        return environment.component.document.uri
+                    case 'basename':
+                        return basename(environment.component.document.uri)
+                    case 'dirname':
+                        return dirname(environment.component.document.uri)
+                    case 'extname':
+                        return extname(environment.component.document.uri)
+                    case 'language':
+                        return environment.component.document.languageId
+                    case 'textContent':
+                        return environment.component.document.text
+                    case 'type':
+                        return 'textDocument'
+                }
+            }
+            if (key.startsWith('component.')) {
+                if (!environment.component) {
+                    return undefined
+                }
+                const prop = key.slice('component.'.length)
+                switch (prop) {
+                    case 'type':
+                        return 'textEditor'
+                }
+            }
+            return next.get(key)
+        },
+    }
+}
+
+/** Filters out items whose `when` context expression evaluates to false (or a falsey value). */
+export function contextFilter<T extends { when?: string }>(context: Context, items: T[]): T[] {
+    const keep: T[] = []
+    for (const item of items) {
+        if (item.when !== undefined) {
+            if (!evaluate(item.when, createChildContext(context))) {
+                continue // omit
+            }
+        }
+        keep.push(item)
+    }
+    return keep
+}

--- a/src/environment/context/expr/evaluator.test.ts
+++ b/src/environment/context/expr/evaluator.test.ts
@@ -1,0 +1,63 @@
+import assert from 'assert'
+import { evaluate, evaluateTemplate } from './evaluator'
+
+const FIXTURE_CONTEXT = () =>
+    new Map<string, any>(
+        Object.entries({
+            a: 1,
+            b: 1,
+            c: 2,
+            x: 'y',
+        })
+    )
+
+describe('evaluate', () => {
+    // tslint:disable:no-invalid-template-strings
+    const TESTS = {
+        a: 1,
+        'a + b': 2,
+        'a == b': true,
+        'a != b': false,
+        'a + b == c': true,
+        x: 'y',
+        '!a': false,
+        '!!a': true,
+        'a && c': 2,
+        'a || b': 1,
+        '(a + b) * 2': 4,
+        'x == "y"': true,
+        '`a`': 'a',
+        '`${x}`': 'y',
+        '`a${x}b`': 'ayb',
+        '`_${x}_${a}_${a+b}`': '_y_1_2',
+        '`_${`-${x}-`}_`': '_-y-_',
+        'a || isnotdefined': 1, // short-circuit (if not, the use of an undefined ident would cause an error)
+        'x = 3': 3,
+        'a = a + 1': 2,
+    }
+    // tslint:enable:no-invalid-template-strings
+    for (const [expr, want] of Object.entries(TESTS)) {
+        it(expr, () => {
+            const value = evaluate(expr, FIXTURE_CONTEXT())
+            assert.strictEqual(value, want)
+        })
+    }
+})
+
+describe('evaluateTemplate', () => {
+    // tslint:disable:no-invalid-template-strings
+    const TESTS = {
+        a: 'a',
+        '${x}': 'y',
+        'a${x}b': 'ayb',
+        '_${x}_${a}_${a+b}': '_y_1_2',
+        '_${`-${x}-`}_': '_-y-_',
+    }
+    // tslint:enable:no-invalid-template-strings
+    for (const [template, want] of Object.entries(TESTS)) {
+        it(template, () => {
+            const value = evaluateTemplate(template, FIXTURE_CONTEXT())
+            assert.strictEqual(value, want)
+        })
+    }
+})

--- a/src/environment/context/expr/lexer.test.ts
+++ b/src/environment/context/expr/lexer.test.ts
@@ -1,0 +1,210 @@
+import assert from 'assert'
+import { Lexer, OPERATOR_CHARS, OPERATORS, OperatorTree, TemplateLexer, Token, TokenType } from './lexer'
+
+describe('Lexer', () => {
+    const l = new Lexer()
+
+    it('scans an expression', () => {
+        l.reset('ab * 2')
+        assert.deepStrictEqual(l.peek(), { type: TokenType.Identifier, value: 'ab' } as Token)
+        const token = l.next()
+        assert.deepStrictEqual(token, { type: TokenType.Identifier, value: 'ab', start: 0, end: 2 } as Token)
+        assert.ok(l.next())
+        assert.ok(l.next())
+        assert.strictEqual(l.peek(), undefined)
+        assert.strictEqual(l.next(), undefined)
+
+        l.reset('a')
+        assert.deepStrictEqual(l.next(), { type: TokenType.Identifier, value: 'a', start: 0, end: 1 } as Token)
+    })
+
+    it('scans identifier with dots', () =>
+        assert.deepStrictEqual(scanAll(l, 'a.b'), [
+            { type: TokenType.Identifier, value: 'a.b', start: 0, end: 3 },
+        ] as Token[]))
+
+    it('scans string', () =>
+        assert.deepStrictEqual(scanAll(l, '"a\\nb\\"c\'d"'), [
+            { type: TokenType.String, value: 'a\nb"c\'d', start: 0, end: 11 },
+        ] as Token[]))
+
+    // tslint:disable:no-invalid-template-strings
+    describe('templates', () => {
+        it('scans no-substitution template', () =>
+            assert.deepStrictEqual(scanAll(l, '`a`'), [
+                { type: TokenType.NoSubstitutionTemplate, value: 'a', start: 0, end: 3 },
+            ] as Token[]))
+
+        it('scans template with empty head/tail', () =>
+            assert.deepStrictEqual(scanAll(l, '`${x}`'), [
+                { type: TokenType.TemplateHead, value: '', start: 0, end: 3 },
+                { type: TokenType.Identifier, value: 'x', start: 3, end: 4 },
+                { type: TokenType.TemplateTail, value: '', start: 4, end: 6 },
+            ] as Token[]))
+
+        it('scans template with empty head/tail and multiple tokens', () =>
+            assert.deepStrictEqual(scanAll(l, '`${x+y}`'), [
+                { type: TokenType.TemplateHead, value: '', start: 0, end: 3 },
+                { type: TokenType.Identifier, value: 'x', start: 3, end: 4 },
+                { type: TokenType.Operator, value: '+', start: 4, end: 5 },
+                { type: TokenType.Identifier, value: 'y', start: 5, end: 6 },
+                { type: TokenType.TemplateTail, value: '', start: 6, end: 8 },
+            ] as Token[]))
+
+        it('scans template with non-empty head, empty tail', () =>
+            assert.deepStrictEqual(scanAll(l, '`a${x}`'), [
+                { type: TokenType.TemplateHead, value: 'a', start: 0, end: 4 },
+                { type: TokenType.Identifier, value: 'x', start: 4, end: 5 },
+                { type: TokenType.TemplateTail, value: '', start: 5, end: 7 },
+            ] as Token[]))
+
+        it('scans template with empty head, non-empty tail', () =>
+            assert.deepStrictEqual(scanAll(l, '`${x}b`'), [
+                { type: TokenType.TemplateHead, value: '', start: 0, end: 3 },
+                { type: TokenType.Identifier, value: 'x', start: 3, end: 4 },
+                { type: TokenType.TemplateTail, value: 'b', start: 4, end: 7 },
+            ] as Token[]))
+
+        it('scans template with non-empty head/tail', () =>
+            assert.deepStrictEqual(scanAll(l, '`a${x}b`'), [
+                { type: TokenType.TemplateHead, value: 'a', start: 0, end: 4 },
+                { type: TokenType.Identifier, value: 'x', start: 4, end: 5 },
+                { type: TokenType.TemplateTail, value: 'b', start: 5, end: 8 },
+            ] as Token[]))
+
+        it('scans template with middle and empty values', () =>
+            assert.deepStrictEqual(scanAll(l, '`${x}${y}`'), [
+                { type: TokenType.TemplateHead, value: '', start: 0, end: 3 },
+                { type: TokenType.Identifier, value: 'x', start: 3, end: 4 },
+                { type: TokenType.TemplateMiddle, value: '', start: 4, end: 7 },
+                { type: TokenType.Identifier, value: 'y', start: 7, end: 8 },
+                { type: TokenType.TemplateTail, value: '', start: 8, end: 10 },
+            ] as Token[]))
+
+        it('scans template with middle', () =>
+            assert.deepStrictEqual(scanAll(l, '`a${x}b${y}c`'), [
+                { type: TokenType.TemplateHead, value: 'a', start: 0, end: 4 },
+                { type: TokenType.Identifier, value: 'x', start: 4, end: 5 },
+                { type: TokenType.TemplateMiddle, value: 'b', start: 5, end: 9 },
+                { type: TokenType.Identifier, value: 'y', start: 9, end: 10 },
+                { type: TokenType.TemplateTail, value: 'c', start: 10, end: 13 },
+            ] as Token[]))
+
+        it('scans nested no-substitution template', () =>
+            assert.deepStrictEqual(scanAll(l, '`a${`x`}b`'), [
+                { type: TokenType.TemplateHead, value: 'a', start: 0, end: 4 },
+                { type: TokenType.NoSubstitutionTemplate, value: 'x', start: 4, end: 7 },
+                { type: TokenType.TemplateTail, value: 'b', start: 7, end: 10 },
+            ] as Token[]))
+
+        it('scans nested template', () =>
+            assert.deepStrictEqual(scanAll(l, '`a${`x${y}z`}b`'), [
+                { type: TokenType.TemplateHead, value: 'a', start: 0, end: 4 },
+                { type: TokenType.TemplateHead, value: 'x', start: 4, end: 8 },
+                { type: TokenType.Identifier, value: 'y', start: 8, end: 9 },
+                { type: TokenType.TemplateTail, value: 'z', start: 9, end: 12 },
+                { type: TokenType.TemplateTail, value: 'b', start: 12, end: 15 },
+            ] as Token[]))
+
+        it('throws on unclosed expression', () => assert.throws(() => scanAll(l, 'x${')))
+    })
+    // tslint:enable:no-invalid-template-strings
+
+    it('throws on unclosed string', () => {
+        l.reset('"a')
+        assert.throws(() => l.next())
+    })
+
+    it('scans single-char binary operators', () =>
+        assert.deepStrictEqual(scanAll(l, 'a = b'), [
+            { type: TokenType.Identifier, value: 'a', start: 0, end: 1 },
+            { type: TokenType.Operator, value: '=', start: 2, end: 3 },
+            { type: TokenType.Identifier, value: 'b', start: 4, end: 5 },
+        ] as Token[]))
+
+    it('scans 2-char binary operators', () =>
+        assert.deepStrictEqual(scanAll(l, 'a == b'), [
+            { type: TokenType.Identifier, value: 'a', start: 0, end: 1 },
+            { type: TokenType.Operator, value: '==', start: 2, end: 4 },
+            { type: TokenType.Identifier, value: 'b', start: 5, end: 6 },
+        ] as Token[]))
+
+    it('scans 3-char binary operators', () =>
+        assert.deepStrictEqual(scanAll(l, 'a !== b'), [
+            { type: TokenType.Identifier, value: 'a', start: 0, end: 1 },
+            { type: TokenType.Operator, value: '!==', start: 2, end: 5 },
+            { type: TokenType.Identifier, value: 'b', start: 6, end: 7 },
+        ] as Token[]))
+
+    it('scans adjacent operators', () => {
+        assert.deepStrictEqual(scanAll(l, 'a==!b'), [
+            { type: TokenType.Identifier, value: 'a', start: 0, end: 1 },
+            { type: TokenType.Operator, value: '==', start: 1, end: 3 },
+            { type: TokenType.Operator, value: '!', start: 3, end: 4 },
+            { type: TokenType.Identifier, value: 'b', start: 4, end: 5 },
+        ] as Token[])
+    })
+
+    describe('constants', () => {
+        it('OPERATOR_CHARS', () => {
+            const maxOpLength = Math.max(...Object.keys(OPERATORS).map(s => s.length))
+            for (const op of Object.keys(OPERATORS)) {
+                if (op.length === 1) {
+                    assert.ok(
+                        OPERATOR_CHARS[op] === true ||
+                            (OPERATOR_CHARS[op] as { [ch: string]: OperatorTree })['\x00'] === true,
+                        op
+                    )
+                } else if (op.length === 2) {
+                    assert.ok(
+                        (OPERATOR_CHARS[op.charAt(0)] as { [ch: string]: OperatorTree })[op.charAt(1)] === true ||
+                            ((OPERATOR_CHARS[op.charAt(0)] as { [ch: string]: OperatorTree })[op.charAt(1)] as {
+                                [ch: string]: OperatorTree
+                            })['\x00'] === true,
+                        op
+                    )
+                } else if (op.length === 3) {
+                    assert.ok(
+                        ((OPERATOR_CHARS[op.charAt(0)] as { [ch: string]: OperatorTree })[op.charAt(1)] as {
+                            [ch: string]: OperatorTree
+                        })[op.charAt(2)] === true ||
+                            (((OPERATOR_CHARS[op.charAt(0)] as { [ch: string]: OperatorTree })[op.charAt(1)] as {
+                                [ch: string]: OperatorTree
+                            })[op.charAt(2)] as { [ch: string]: OperatorTree })['\x00'] === true,
+                        op
+                    )
+                } else if (op.length > maxOpLength) {
+                    throw new Error(`operators of length ${op.length} are not yet supported`)
+                }
+            }
+        })
+    })
+})
+
+describe('TemplateLexer', () => {
+    const l = new TemplateLexer()
+
+    it('scans template with middle', () =>
+        // tslint:disable-next-line:no-invalid-template-strings
+        assert.deepStrictEqual(scanAll(l, 'a${x}b${y}c'), [
+            { type: TokenType.TemplateHead, value: 'a', start: 0, end: 3 },
+            { type: TokenType.Identifier, value: 'x', start: 3, end: 4 },
+            { type: TokenType.TemplateMiddle, value: 'b', start: 4, end: 8 },
+            { type: TokenType.Identifier, value: 'y', start: 8, end: 9 },
+            { type: TokenType.TemplateTail, value: 'c', start: 9, end: 11 },
+        ] as Token[]))
+})
+
+function scanAll(l: Lexer, exprStr: string): Token[] {
+    const tokens: Token[] = []
+    l.reset(exprStr)
+    while (true) {
+        const token = l.next()
+        if (token) {
+            tokens.push(token)
+        } else {
+            break
+        }
+    }
+    return tokens
+}

--- a/src/environment/context/expr/lexer.ts
+++ b/src/environment/context/expr/lexer.ts
@@ -1,0 +1,481 @@
+/** Valid token types in expressions. */
+export enum TokenType {
+    /** An operator. */
+    Operator,
+
+    /** An identifier. */
+    Identifier,
+
+    /** A string literal. */
+    String,
+
+    /**
+     * The start of a template until its first expression.
+     *
+     * See https://tc39.github.io/ecma262/#sec-template-literal-lexical-components for documentation on the
+     * ECMAScript lexical components for templates, upon which this is based.
+     */
+    TemplateHead,
+
+    /** The end of a previous template expression until the next template expression. */
+    TemplateMiddle,
+
+    /** The end of a previous template expression until the end of the template. */
+    TemplateTail,
+
+    /** A template with no substitutions. */
+    NoSubstitutionTemplate,
+
+    /** A number literal. */
+    Number,
+}
+
+/** A token that the expression lexer scanned in an expression. */
+export interface Token {
+    /** The type of this token. */
+    type: TokenType
+
+    /**
+     * The token's value.
+     *
+     * For string and template literals, this is the parsed string value (after accounting for escape sequences but
+     * not template expressions). For number literals, this is the (unparsed) string representation.
+     */
+    value: any
+
+    /** The start character position of this token. */
+    start: number
+
+    /** The end character position of this token. */
+    end: number
+}
+
+/**
+ * All valid operators in expressions. The values are the operator precedence (or, for operators that are not operators, 0). This
+ * must be kept in sync with OPERATOR_CHARS.
+ *
+ * Exported for testing only.
+ */
+export const OPERATORS = {
+    '(': 0,
+    ')': 0,
+    '}': 0,
+    ',': 0,
+    '=': 0,
+    '||': 1,
+    '&&': 2,
+    '^': 4,
+    '==': 6,
+    '!=': 6,
+    '===': 6,
+    '!==': 6,
+    '<': 7,
+    '>': 7,
+    '<=': 7,
+    '>=': 7,
+    '+': 9,
+    '-': 9,
+    '*': 10,
+    '/': 10,
+    '%': 10,
+    '!': 11,
+}
+
+/** All valid operators. */
+export type Operator = keyof typeof OPERATORS
+
+export type OperatorTree = boolean | { [ch: string]: OperatorTree }
+
+/**
+ * A tree with the next valid operator characters for multi-character operators. This must be kept in sync with
+ * OPERATORS.
+ *
+ * Exported for testing only.
+ */
+export const OPERATOR_CHARS: { [ch: string]: OperatorTree } = {
+    '&': { '&': true },
+    '|': { '|': true },
+    '=': {
+        '\x00': true,
+        '=': {
+            '\x00': true,
+            '=': true,
+        },
+    },
+    '!': {
+        '\x00': true,
+        '=': {
+            '\x00': true,
+            '=': true,
+        },
+    },
+    '<': { '\x00': true, '=': true },
+    '>': { '\x00': true, '=': true },
+    '^': true,
+    '}': true,
+    '(': true,
+    ')': true,
+    ',': true,
+    '+': true,
+    '-': true,
+    '*': true,
+    '/': true,
+    '%': true,
+}
+
+function isWhiteSpace(ch: string): boolean {
+    return ch === '\u0009' || ch === ' ' || ch === '\u00A0'
+}
+
+function isLetter(ch: string): boolean {
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+}
+
+function isDecimalDigit(ch: string): boolean {
+    return ch >= '0' && ch <= '9'
+}
+
+function isIdentifierStart(ch: string): boolean {
+    return ch === '_' || isLetter(ch)
+}
+
+function isIdentifierPart(ch: string): boolean {
+    return isIdentifierStart(ch) || isDecimalDigit(ch) || ch === '.'
+}
+
+/** Scans an expression. */
+export class Lexer {
+    private expression = ''
+    private length = 0
+    protected _index = 0
+    private marker = 0
+    protected curlyStack = 0
+
+    /** The current character position of the lexer's cursor. */
+    public get index(): number {
+        return this._index
+    }
+
+    public reset(str: string): void {
+        this.expression = str
+        this.length = str.length
+        this._index = 0
+        this.curlyStack = 0
+    }
+
+    public next(): Token | undefined {
+        this.skipSpaces()
+        if (this._index >= this.length) {
+            return undefined
+        }
+
+        this.marker = this._index
+
+        const token = this.scanNext()
+        if (token !== undefined) {
+            return token
+        }
+
+        throw new SyntaxError(`Unexpected character ${JSON.stringify(this.peekNextChar())} (at ${this.index})`)
+    }
+
+    public peek(): Pick<Token, Exclude<keyof Token, 'start' | 'end'>> | undefined {
+        const savedIndex = this._index
+        const savedCurlyStack = this.curlyStack
+        let token: Token | undefined
+        try {
+            token = this.next()
+            if (token) {
+                delete token.start
+                delete token.end
+            }
+        } catch (e) {
+            token = undefined
+        }
+        this._index = savedIndex
+        this.curlyStack = savedCurlyStack
+
+        return token
+    }
+
+    protected scanNext(): Token | undefined {
+        let token = this.scanString()
+        if (token !== undefined) {
+            return token
+        }
+
+        token = this.scanTemplate()
+        if (token !== undefined) {
+            return token
+        }
+
+        token = this.scanNumber()
+        if (token !== undefined) {
+            return token
+        }
+
+        token = this.scanOperator()
+        if (token !== undefined) {
+            return token
+        }
+
+        token = this.scanIdentifier()
+        if (token !== undefined) {
+            return token
+        }
+
+        return undefined
+    }
+
+    private peekNextChar(advance = 0): string {
+        const idx = this._index + advance
+        return idx < this.length ? this.expression.charAt(idx) : '\x00'
+    }
+
+    private getNextChar(): string {
+        let ch = '\x00'
+        const idx = this._index
+        if (idx < this.length) {
+            ch = this.expression.charAt(idx)
+            this._index += 1
+        }
+        return ch
+    }
+
+    private createToken(type: TokenType, value: any): Token {
+        return {
+            type,
+            value,
+            start: this.marker,
+            end: this._index,
+        }
+    }
+
+    private skipSpaces(): void {
+        while (this._index < this.length) {
+            const ch = this.peekNextChar()
+            if (!isWhiteSpace(ch)) {
+                break
+            }
+            this.getNextChar()
+        }
+    }
+
+    private scanOperator(): Token | undefined {
+        let searchTree: OperatorTree | boolean = OPERATOR_CHARS
+        let value = ''
+        while (searchTree && searchTree !== true) {
+            const ch = this.peekNextChar()
+            searchTree = searchTree[ch]
+            if (searchTree) {
+                value += ch
+                this.getNextChar()
+            }
+        }
+        if (value === '}') {
+            this.curlyStack--
+        }
+        if (value === '') {
+            return undefined
+        }
+        return this.createToken(TokenType.Operator, value)
+    }
+
+    private scanIdentifier(): Token | undefined {
+        let ch = this.peekNextChar()
+        if (!isIdentifierStart(ch)) {
+            return undefined
+        }
+
+        let id = this.getNextChar()
+        while (true) {
+            ch = this.peekNextChar()
+            if (!isIdentifierPart(ch)) {
+                break
+            }
+            id += this.getNextChar()
+        }
+
+        return this.createToken(TokenType.Identifier, id)
+    }
+
+    private scanString(): Token | undefined {
+        const quote = this.peekNextChar()
+        if (quote !== "'" && quote !== '"') {
+            return undefined
+        }
+        this.getNextChar()
+
+        let terminated = false
+        let str = ''
+        while (this._index < this.length) {
+            const ch = this.getNextChar()
+            if (ch === quote) {
+                terminated = true
+                break
+            } else if (ch === '\\') {
+                str += backslashEscapeCodeString(this.getNextChar())
+            } else {
+                str += ch
+            }
+        }
+        if (!terminated) {
+            throw new Error(`Unterminated string literal (at ${this.index})`)
+        }
+        return this.createToken(TokenType.String, str)
+    }
+
+    private scanTemplate(): Token | undefined {
+        const ch = this.peekNextChar()
+        // tslint:disable-next-line:no-invalid-template-strings
+        if (!(ch === '`' || (ch === '}' && this.curlyStack > 0))) {
+            return undefined
+        }
+        this.getNextChar()
+
+        const head = ch === '`'
+        return this.doScanTemplate(head)
+    }
+
+    protected backtick(): boolean {
+        return true
+    }
+
+    protected doScanTemplate(head: boolean): Token {
+        let tail = false
+
+        let terminated = false
+        let hasSubstitution = false
+        let str = ''
+        while (this._index < this.length) {
+            const ch = this.getNextChar()
+            if (ch === '`' && this.backtick()) {
+                tail = true
+                terminated = true
+                break
+            } else if (ch === '\\') {
+                str += backslashEscapeCodeString(this.getNextChar())
+            } else {
+                if (ch === '$') {
+                    const ch2 = this.peekNextChar()
+                    if (ch2 === '{') {
+                        // tslint:disable-next-line:no-invalid-template-strings
+                        this.curlyStack++
+                        this.getNextChar()
+                        terminated = true
+                        hasSubstitution = true
+                        break
+                    }
+                }
+                str += ch
+            }
+        }
+        if (!head) {
+            this.curlyStack--
+        }
+        if (this.backtick()) {
+            if (!terminated) {
+                throw new Error(`Unterminated template literal (at ${this.index})`)
+            }
+        } else if (this._index === this.length) {
+            tail = true
+        }
+
+        let type: TokenType
+        if (head && terminated && !hasSubstitution) {
+            type = TokenType.NoSubstitutionTemplate
+        } else if (head) {
+            type = TokenType.TemplateHead
+        } else if (tail) {
+            type = TokenType.TemplateTail
+        } else {
+            type = TokenType.TemplateMiddle
+        }
+        return this.createToken(type, str)
+    }
+
+    private scanNumber(): Token | undefined {
+        let ch = this.peekNextChar()
+        if (!isDecimalDigit(ch) && ch !== '.') {
+            return undefined
+        }
+
+        let num = ''
+        if (ch !== '.') {
+            num = this.getNextChar()
+            while (true) {
+                ch = this.peekNextChar()
+                if (!isDecimalDigit(ch)) {
+                    break
+                }
+                num += this.getNextChar()
+            }
+        }
+
+        if (ch === '.') {
+            num += this.getNextChar()
+            while (true) {
+                ch = this.peekNextChar()
+                if (!isDecimalDigit(ch)) {
+                    break
+                }
+                num += this.getNextChar()
+            }
+        }
+
+        if (ch === 'e' || ch === 'E') {
+            num += this.getNextChar()
+            ch = this.peekNextChar()
+            if (ch === '+' || ch === '-' || isDecimalDigit(ch)) {
+                num += this.getNextChar()
+                while (true) {
+                    ch = this.peekNextChar()
+                    if (!isDecimalDigit(ch)) {
+                        break
+                    }
+                    num += this.getNextChar()
+                }
+            } else {
+                ch = `character ${JSON.stringify(ch)}`
+                if (this._index >= this.length) {
+                    ch = '<end>'
+                }
+                throw new SyntaxError(`Unexpected ${ch} after the exponent sign (at ${this.index})`)
+            }
+        }
+
+        if (num === '.') {
+            throw new SyntaxError(`Expected decimal digits after the dot sign (at ${this.index})`)
+        }
+
+        return this.createToken(TokenType.Number, num)
+    }
+}
+
+/** Scans a template. */
+export class TemplateLexer extends Lexer {
+    public next(): Token | undefined {
+        if (this._index === 0) {
+            return this.doScanTemplate(true)
+        }
+        return super.next()
+    }
+
+    protected backtick(): boolean {
+        // The root is not surrounded with backticks.
+        return this.curlyStack !== 0
+    }
+}
+
+function backslashEscapeCodeString(ch: string): string {
+    switch (ch) {
+        case 'n':
+            return '\n'
+        case 'r':
+            return '\r'
+        case 't':
+            return '\t'
+        default:
+            return ch
+    }
+}

--- a/src/environment/context/expr/parser.test.ts
+++ b/src/environment/context/expr/parser.test.ts
@@ -1,0 +1,244 @@
+import assert from 'assert'
+import { TokenType } from './lexer'
+import { Expression, Parser, TemplateParser } from './parser'
+
+describe('Parser', () => {
+    const TESTS: { [expr: string]: Expression } = {
+        '!a': {
+            Unary: {
+                operator: '!',
+                expression: { Identifier: 'a' },
+            },
+        },
+        '"a"': {
+            Literal: {
+                type: TokenType.String,
+                value: 'a',
+            },
+        },
+        '`a`': {
+            Literal: {
+                type: TokenType.String,
+                value: 'a',
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`${x}`': {
+            Template: {
+                parts: [{ Identifier: 'x' }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`${x}${y}`': {
+            Template: {
+                parts: [{ Identifier: 'x' }, { Identifier: 'y' }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`${x+y}`': {
+            Template: {
+                parts: [
+                    {
+                        Binary: {
+                            left: { Identifier: 'x' },
+                            operator: '+',
+                            right: { Identifier: 'y' },
+                        },
+                    },
+                ],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`a${x}`': {
+            Template: {
+                parts: [{ Literal: { type: TokenType.String, value: 'a' } }, { Identifier: 'x' }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`${x}b`': {
+            Template: {
+                parts: [{ Identifier: 'x' }, { Literal: { type: TokenType.String, value: 'b' } }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`a${x}b`': {
+            Template: {
+                parts: [
+                    { Literal: { type: TokenType.String, value: 'a' } },
+                    { Identifier: 'x' },
+                    { Literal: { type: TokenType.String, value: 'b' } },
+                ],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`a${x}b${y}c`': {
+            Template: {
+                parts: [
+                    { Literal: { type: TokenType.String, value: 'a' } },
+                    { Identifier: 'x' },
+                    { Literal: { type: TokenType.String, value: 'b' } },
+                    { Identifier: 'y' },
+                    { Literal: { type: TokenType.String, value: 'c' } },
+                ],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '`a${`x${y}z`}b`': {
+            Template: {
+                parts: [
+                    { Literal: { type: TokenType.String, value: 'a' } },
+                    {
+                        Template: {
+                            parts: [
+                                { Literal: { type: TokenType.String, value: 'x' } },
+                                { Identifier: 'y' },
+                                { Literal: { type: TokenType.String, value: 'z' } },
+                            ],
+                        },
+                    },
+                    { Literal: { type: TokenType.String, value: 'b' } },
+                ],
+            },
+        },
+        'a && b': {
+            Binary: {
+                left: { Identifier: 'a' },
+                operator: '&&',
+                right: { Identifier: 'b' },
+            },
+        },
+        '(a + b) * c': {
+            Binary: {
+                left: {
+                    Binary: {
+                        left: { Identifier: 'a' },
+                        operator: '+',
+                        right: { Identifier: 'b' },
+                    },
+                },
+                operator: '*',
+                right: { Identifier: 'c' },
+            },
+        },
+        'ab * 1 + x(2, 3)': {
+            Binary: {
+                left: {
+                    Binary: {
+                        left: { Identifier: 'ab' },
+                        operator: '*',
+                        right: { Literal: { type: TokenType.Number, value: '1' } },
+                    },
+                },
+                operator: '+',
+                right: {
+                    FunctionCall: {
+                        name: 'x',
+                        args: [
+                            { Literal: { type: TokenType.Number, value: '2' } },
+                            { Literal: { type: TokenType.Number, value: '3' } },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+    const parser = new Parser()
+    for (const [expr, want] of Object.entries(TESTS)) {
+        it(expr, () => assert.deepStrictEqual(parser.parse(expr), want))
+    }
+
+    it('throws an error on an invalid argument list', () => assert.throws(() => parser.parse('a(1,,)')))
+    it('throws an error on an unclosed string', () => assert.throws(() => parser.parse('"')))
+    it('throws an error on an unclosed template', () => assert.throws(() => parser.parse('`')))
+    it('throws an error on an invalid unary operator', () => assert.throws(() => parser.parse('!')))
+    it('throws an error on an invalid binary operator', () => assert.throws(() => parser.parse('a*')))
+    it('throws an error on an unclosed function call', () => assert.throws(() => parser.parse('a(')))
+    it('throws an error on an unterminated expression', () => assert.throws(() => parser.parse('(a=')))
+})
+
+describe('TemplateParser', () => {
+    const TESTS: { [template: string]: Expression } = {
+        // tslint:disable-next-line:no-invalid-template-strings
+        '${x}': {
+            Template: {
+                parts: [{ Identifier: 'x' }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '${x}${y}': {
+            Template: {
+                parts: [{ Identifier: 'x' }, { Identifier: 'y' }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '${x+y}': {
+            Template: {
+                parts: [
+                    {
+                        Binary: {
+                            left: { Identifier: 'x' },
+                            operator: '+',
+                            right: { Identifier: 'y' },
+                        },
+                    },
+                ],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        'a${x}': {
+            Template: {
+                parts: [{ Literal: { type: TokenType.String, value: 'a' } }, { Identifier: 'x' }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        '${x}b': {
+            Template: {
+                parts: [{ Identifier: 'x' }, { Literal: { type: TokenType.String, value: 'b' } }],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        'a${x}b': {
+            Template: {
+                parts: [
+                    { Literal: { type: TokenType.String, value: 'a' } },
+                    { Identifier: 'x' },
+                    { Literal: { type: TokenType.String, value: 'b' } },
+                ],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        'a${x}b${y}c': {
+            Template: {
+                parts: [
+                    { Literal: { type: TokenType.String, value: 'a' } },
+                    { Identifier: 'x' },
+                    { Literal: { type: TokenType.String, value: 'b' } },
+                    { Identifier: 'y' },
+                    { Literal: { type: TokenType.String, value: 'c' } },
+                ],
+            },
+        },
+        // tslint:disable-next-line:no-invalid-template-strings
+        'a${`x${y}z`}b': {
+            Template: {
+                parts: [
+                    { Literal: { type: TokenType.String, value: 'a' } },
+                    {
+                        Template: {
+                            parts: [
+                                { Literal: { type: TokenType.String, value: 'x' } },
+                                { Identifier: 'y' },
+                                { Literal: { type: TokenType.String, value: 'z' } },
+                            ],
+                        },
+                    },
+                    { Literal: { type: TokenType.String, value: 'b' } },
+                ],
+            },
+        },
+    }
+    const parser = new TemplateParser()
+    for (const [template, want] of Object.entries(TESTS)) {
+        it(template, () => assert.deepStrictEqual(parser.parse(template), want))
+    }
+})

--- a/src/environment/context/expr/parser.ts
+++ b/src/environment/context/expr/parser.ts
@@ -1,0 +1,311 @@
+import { Lexer, Operator, TemplateLexer, Token, TokenType } from './lexer'
+
+export type Expression =
+    | { FunctionCall: { name: string; args: Expression[] } }
+    | { Identifier: string }
+    | { Literal: { type: TokenType.String | TokenType.Number; value: string } }
+    | { Template: { parts: Expression[] } }
+    | { Unary: { operator: Operator; expression: Expression } }
+    | { Binary: { operator: Operator; left: Expression; right: Expression } }
+    | { Assignment: { name: Expression; value: Expression } }
+
+/**
+ * Parses an expression.
+ *
+ * TODO: Operator precedence is not handled correctly. Use parentheses to be explicit about your desired
+ * precedence.
+ */
+export class Parser {
+    protected lexer!: Lexer
+
+    public parse(exprStr: string): Expression {
+        if (!this.lexer) {
+            this.lexer = new Lexer()
+        }
+        this.lexer.reset(exprStr)
+        const expr = this.parseExpression()
+
+        const token = this.lexer.next()
+        if (token !== undefined) {
+            throw new SyntaxError(
+                `Unexpected token at end of input: ${JSON.stringify(token.value)} (at ${this.lexer.index})`
+            )
+        }
+
+        return expr
+    }
+
+    // ArgumentList := Expression |
+    //                 Expression ',' ArgumentList
+    private parseArgumentList(): Expression[] {
+        const args: Expression[] = []
+        while (true) {
+            const expr = this.parseExpression()
+            if (expr === undefined) {
+                throw new Error(
+                    `Parse error on token in arguments list: ${JSON.stringify(this.lexer.peek())} (at ${
+                        this.lexer.index
+                    })`
+                )
+            }
+            args.push(expr)
+            const token = this.lexer.peek()
+            if (!matchOp(token, ',')) {
+                break
+            }
+            this.lexer.next()
+        }
+        return args
+    }
+
+    // FunctionCall ::= Identifier '(' ')' ||
+    //                  Identifier '(' ArgumentList ')'
+    private parseFunctionCall(name: string): Expression {
+        let token: Pick<Token, 'type' | 'value'> | undefined = this.lexer.next()
+        if (!matchOp(token, '(')) {
+            throw new SyntaxError(`Expected "(" in function call ${JSON.stringify(name)} (at ${this.lexer.index})`)
+        }
+
+        token = this.lexer.peek()
+        const args: Expression[] = matchOp(token, ')') ? [] : this.parseArgumentList()
+
+        token = this.lexer.next()
+        if (!matchOp(token, ')')) {
+            throw new SyntaxError(`Expected ")" in function call ${JSON.stringify(name)} (at ${this.lexer.index})`)
+        }
+
+        return {
+            FunctionCall: {
+                name,
+                args,
+            },
+        }
+    }
+
+    private parseTemplateParts(): Expression[] {
+        const parts: Expression[] = []
+        while (true) {
+            const token: Pick<Token, 'type' | 'value'> | undefined = this.lexer.peek()
+            if (!token) {
+                break
+            }
+            if (token.type === TokenType.TemplateTail) {
+                if (token.value) {
+                    parts.push({ Literal: { type: TokenType.String, value: token.value } })
+                }
+                this.lexer.next()
+                break
+            }
+            if (matchOp(token, '}')) {
+                this.lexer.next()
+            } else if (token.type === TokenType.TemplateMiddle) {
+                if (token.value) {
+                    parts.push({ Literal: { type: TokenType.String, value: token.value } })
+                }
+                this.lexer.next()
+            } else {
+                parts.push(this.parseExpression())
+            }
+        }
+        return parts
+    }
+
+    protected parseTemplate(): Expression {
+        const token = this.lexer.peek()
+        if (token === undefined) {
+            throw new SyntaxError(
+                `Unexpected termination of expression at beginning of template (at ${this.lexer.index})`
+            )
+        }
+
+        if (token.type === TokenType.NoSubstitutionTemplate) {
+            this.lexer.next()
+            // The caller doesn't need to distinguish between NoSubstitutionTemplate and String
+            // tokens, so collapse both token types into String.
+            return { Literal: { type: TokenType.String, value: token.value } }
+        }
+
+        if (token.type === TokenType.TemplateHead || token.type === TokenType.TemplateMiddle) {
+            this.lexer.next()
+            const parts = this.parseTemplateParts()
+            if (token.value) {
+                parts.unshift({ Literal: { type: TokenType.String, value: token.value } })
+            }
+            return {
+                Template: { parts },
+            }
+        }
+
+        throw new SyntaxError(
+            `Unexpected token at beginning of template: ${JSON.stringify(token.value)} (at ${this.lexer.index})`
+        )
+    }
+
+    // Primary ::= Identifier |
+    //             String |
+    //             Template |
+    //             Number |
+    //             '(' Assignment ')' |
+    //             FunctionCall
+    private parsePrimary(): Expression {
+        const token = this.lexer.peek()
+        if (token === undefined) {
+            throw new SyntaxError(`Unexpected termination of expression (at ${this.lexer.index})`)
+        }
+
+        if (token.type === TokenType.Identifier) {
+            this.lexer.next()
+            if (matchOp(this.lexer.peek(), '(')) {
+                return this.parseFunctionCall(token.value)
+            }
+            return {
+                Identifier: token.value,
+            }
+        }
+
+        if (token.type === TokenType.String || token.type === TokenType.Number) {
+            this.lexer.next()
+            return { Literal: { type: token.type, value: token.value } }
+        }
+
+        if (
+            token.type === TokenType.NoSubstitutionTemplate ||
+            token.type === TokenType.TemplateHead ||
+            token.type === TokenType.TemplateMiddle
+        ) {
+            return this.parseTemplate()
+        }
+
+        if (matchOp(token, '(')) {
+            this.lexer.next()
+            const expr = this.parseAssignment()
+            const token = this.lexer.next()
+            if (!matchOp(token, ')')) {
+                throw new SyntaxError(`Expected ")" (at ${this.lexer.index})`)
+            }
+            return expr
+        }
+
+        throw new SyntaxError(`Parse error on token: ${JSON.stringify(token.value)} (at ${this.lexer.index})`)
+    }
+
+    // Unary ::= Primary |
+    //           UnaryOp Unary
+    private parseUnary(): Expression {
+        const token = this.lexer.peek()
+        if (token !== undefined && (matchOp(token, '-') || matchOp(token, '+') || matchOp(token, '!'))) {
+            this.lexer.next()
+            const expr = this.parseUnary()
+            return {
+                Unary: {
+                    operator: token.value,
+                    expression: expr,
+                },
+            }
+        }
+        return this.parsePrimary()
+    }
+
+    // Multiplicative ::= Unary |
+    //                    Multiplicative BinaryOp Unary
+    private parseMultiplicative(): Expression {
+        let expr = this.parseUnary()
+        let token = this.lexer.peek()
+        while (token !== undefined && (matchOp(token, '*') || matchOp(token, '/') || matchOp(token, '%'))) {
+            this.lexer.next()
+            expr = {
+                Binary: {
+                    operator: token.value,
+                    left: expr,
+                    right: this.parseUnary(),
+                },
+            }
+            token = this.lexer.peek()
+        }
+        return expr
+    }
+
+    // Additive ::= Multiplicative |
+    //              Additive BinaryOp Multiplicative
+    private parseAdditive(): Expression {
+        let expr = this.parseMultiplicative()
+        let token = this.lexer.peek()
+        while (
+            token !== undefined &&
+            (matchOp(token, '+') ||
+                matchOp(token, '-') ||
+                matchOp(token, '==') ||
+                matchOp(token, '!=') ||
+                matchOp(token, '===') ||
+                matchOp(token, '!==') ||
+                matchOp(token, '<') ||
+                matchOp(token, '>') ||
+                matchOp(token, '<=') ||
+                matchOp(token, '>=') ||
+                matchOp(token, '&&') ||
+                matchOp(token, '||'))
+        ) {
+            this.lexer.next()
+            expr = {
+                Binary: {
+                    operator: token.value,
+                    left: expr,
+                    right: this.parseMultiplicative(),
+                },
+            }
+            token = this.lexer.peek()
+        }
+        return expr
+    }
+
+    // Assignment ::= Identifier '=' Assignment |
+    //                Additive
+    private parseAssignment(): Expression {
+        const expr = this.parseAdditive()
+        if (expr !== undefined && 'Identifier' in expr) {
+            const token = this.lexer.peek()
+            if (matchOp(token, '=')) {
+                this.lexer.next()
+                return {
+                    Assignment: {
+                        name: expr,
+                        value: this.parseAssignment(),
+                    },
+                }
+            }
+            return expr
+        }
+
+        return expr
+    }
+
+    // Expression ::= Assignment
+    private parseExpression(): Expression {
+        return this.parseAssignment()
+    }
+}
+
+/** Parses a template. */
+export class TemplateParser extends Parser {
+    public parse(templateStr: string): Expression {
+        if (!this.lexer) {
+            this.lexer = new TemplateLexer()
+        }
+
+        this.lexer.reset(templateStr)
+        const expr = this.parseTemplate()
+
+        const token = this.lexer.next()
+        if (token !== undefined) {
+            throw new SyntaxError(
+                `Unexpected token at end of template input: ${JSON.stringify(token.value)} (at ${this.lexer.index})`
+            )
+        }
+
+        return expr
+    }
+}
+
+function matchOp(token: Pick<Token, 'type' | 'value'> | undefined, op: Operator): boolean {
+    return token !== undefined && token.type === TokenType.Operator && token.value === op
+}

--- a/src/environment/controller.test.ts
+++ b/src/environment/controller.test.ts
@@ -38,6 +38,7 @@ const FIXTURE_ENVIRONMENT: Environment<any, any> = {
     },
     extensions: [{ id: 'x' }],
     configuration: {},
+    context: new Map([]),
 }
 
 describe('Controller', () => {

--- a/src/environment/controller.ts
+++ b/src/environment/controller.ts
@@ -103,7 +103,7 @@ export class Controller<X extends Extension, C extends ConfigurationCascade> imp
     private subscriptions = new Subscription()
 
     /** The registries for various providers that expose extension functionality. */
-    public readonly registries = new Registries()
+    public readonly registries: Registries<X, C>
 
     private readonly _logMessages = new Subject<LogMessageParams & MessageSource>()
     private readonly _showMessages = new Subject<ShowMessageParams & MessageSource>()
@@ -132,6 +132,8 @@ export class Controller<X extends Extension, C extends ConfigurationCascade> imp
                 c.client.unsubscribe()
             }
         })
+
+        this.registries = new Registries<X, C>(this.environment)
     }
 
     public setEnvironment(nextEnvironment: Environment<X, C>): void {

--- a/src/environment/registries.test.ts
+++ b/src/environment/registries.test.ts
@@ -1,8 +1,9 @@
+import { EMPTY_OBSERVABLE_ENVIRONMENT } from './environment'
 import { Registries } from './registries'
 
 describe('Registries', () => {
     it('initializes empty registries', () => {
         // tslint:disable-next-line:no-unused-expression
-        new Registries()
+        new Registries(EMPTY_OBSERVABLE_ENVIRONMENT)
     })
 })

--- a/src/environment/registries.ts
+++ b/src/environment/registries.ts
@@ -1,14 +1,23 @@
-import { ReferenceParams } from '../protocol'
+import { ConfigurationCascade, ReferenceParams } from '../protocol'
+import { ObservableEnvironment } from './environment'
+import { Extension } from './extension'
 import { CommandRegistry } from './providers/command'
 import { ContributionRegistry } from './providers/contribution'
 import { TextDocumentDecorationProviderRegistry } from './providers/decoration'
 import { TextDocumentHoverProviderRegistry } from './providers/hover'
 import { TextDocumentLocationProviderRegistry } from './providers/location'
 
-/** Registries is a container for all provider registries. */
-export class Registries {
+/**
+ * Registries is a container for all provider registries.
+ *
+ * @template X extension type
+ * @template C settings type
+ */
+export class Registries<X extends Extension, C extends ConfigurationCascade> {
+    constructor(private environment: ObservableEnvironment<X, C>) {}
+
     public readonly commands = new CommandRegistry()
-    public readonly contribution = new ContributionRegistry()
+    public readonly contribution = new ContributionRegistry(this.environment.context)
     public readonly textDocumentDefinition = new TextDocumentLocationProviderRegistry()
     public readonly textDocumentImplementation = new TextDocumentLocationProviderRegistry()
     public readonly textDocumentReferences = new TextDocumentLocationProviderRegistry<ReferenceParams>()

--- a/src/protocol/contribution.ts
+++ b/src/protocol/contribution.ts
@@ -84,6 +84,12 @@ export interface CommandContribution extends CommandItem {
      * (e.g., because the client is not graphical), then the client may hide the item from the toolbar.
      */
     actionItem?: ActionItem
+
+    /**
+     * An expression that, if given, must evaluate to true (or a truthy value) for this contribution to be
+     * displayed. The expression may use values from the context in which the contribution would be displayed.
+     */
+    when?: string
 }
 
 /** A description of how to display a button on a toolbar. */
@@ -156,4 +162,10 @@ export interface MenuContributions extends Partial<Record<ContributableMenu, Men
 export interface MenuItemContribution {
     /** The command to execute when selected (== (CommandContribution).command). */
     command: string
+
+    /**
+     * An expression that, if given, must evaluate to true (or a truthy value) for this contribution to be
+     * displayed. The expression may use values from the context in which the contribution would be displayed.
+     */
+    when?: string
 }


### PR DESCRIPTION
This will help reduce UI jitter when using contributions by making it possible to register contribution(s) once and selectively enable/disable them (i.e., show/hide them) based on other contextual information, such as whether the current text document is has a given file extension or based on a configuration value.

For example, a menu contribution with `"when": "config.blame.show"` would only be shown if the configuration `blame.show` property was truthy. There are other values defined (`resource.basename`, `component.type`, etc.). They will be documented, and more values and functions will be defined, soon. This feature should be considered experimental until then.